### PR TITLE
Issue 11

### DIFF
--- a/antlr4/MODLParser.g4
+++ b/antlr4/MODLParser.g4
@@ -21,7 +21,7 @@ options {
 
 modl
   // Valid MODL is zero or more MODL structures separated by semi-colons, newlines or both
-  : (NEWLINE* modl_structure ( ( SC | NEWLINE+ | SC NEWLINE+ ) modl_structure )* SC?)? NEWLINE* EOF;
+  : (NEWLINE* modl_structure ( NEWLINE* SC? NEWLINE* modl_structure NEWLINE*)* )? NEWLINE* SC? NEWLINE* EOF;
 
 modl_structure
   : modl_map

--- a/antlr4/MODLParser.g4
+++ b/antlr4/MODLParser.g4
@@ -61,7 +61,7 @@ modl_pair
   // It's also possible to do the same with an array pair
   // e.g. numbers[1;2;3] – equivalent to numbers=[1;2;3]
 
-  : ( STRING | QUOTED) EQUALS ( modl_value_item )                              // key = value        (standard pair)
+  : ( STRING | QUOTED) NEWLINE* EQUALS NEWLINE* modl_value_item                // key = value        (standard pair)
   | STRING modl_map                                                            // key( key = value ) (map pair)
   | STRING modl_array                                                          // key[ item; item ]  (array pair)
   ;

--- a/antlr4/MODLParser.g4
+++ b/antlr4/MODLParser.g4
@@ -124,9 +124,9 @@ modl_array_conditional
 modl_value_conditional
   // Conditionals within values DO require else
   // e.g. { country=gb? this /country=us? that /? other }
-  : LCBRAC NEWLINE* modl_condition_test QMARK NEWLINE* modl_value_conditional_return NEWLINE*
+  : LCBRAC NEWLINE* modl_condition_test QMARK (NEWLINE* modl_value_conditional_return NEWLINE*
         (FSLASH NEWLINE* modl_condition_test QMARK NEWLINE* modl_value_conditional_return )* NEWLINE*
-        (FSLASH NEWLINE* QMARK NEWLINE* modl_value_conditional_return) NEWLINE*
+        (FSLASH NEWLINE* QMARK NEWLINE* modl_value_conditional_return) NEWLINE*)?
     RCBRAC
   ;
   modl_value_conditional_return


### PR DESCRIPTION
Interpreters using this version of the grammar will need to support conditionals of the form:

```
a=1
b=2
x={a=b?}
```
Which in this case should result in ``x=false``

The other two grammar changes should be transparent to interpreters since they just allow extra whitespace to aid formatting.