### PR TITLE
Make quotes and graves the same

### DIFF
--- a/antlr4/MODLLexer.g4
+++ b/antlr4/MODLLexer.g4
@@ -40,6 +40,21 @@ lexer grammar MODLLexer;
       : ~[\n\r] *
     ;
 
+  QUOTED
+    // Literal string inside double quotes – any character is allowed inside quotes except for the double quote itself
+    : '"' ( INSIDE_QUOTES ) '"'
+    ;
+    fragment INSIDE_QUOTES
+      : ~["]*
+      ;
+  GRAVED
+    // String inside graves – any character is allowed inside graves except for the grave itself. It is handled by parser
+    : '`' ( INSIDE_GRAVES ) '`'
+    ;
+    fragment INSIDE_GRAVES
+      : ~[`]*
+      ;
+
   STRING : '# '? ( ESCAPED | UNRESERVED | HASH_PREFIX | QUOTED | GRAVED )+ ( ('#'? ' '+ '#'?) ( ESCAPED | UNRESERVED | QUOTED | GRAVED )+ )* ;
     // These two should be identical except for regex inversion on first
     fragment UNRESERVED
@@ -67,20 +82,6 @@ lexer grammar MODLLexer;
     : '#' STRING
     ;
 
-  QUOTED
-    // Literal string inside double quotes – any character is allowed inside quotes except for the double quote itself
-    : '"' (STRING | INSIDE_QUOTES) '"'
-    ;
-    fragment INSIDE_QUOTES
-      : ~["]*
-      ;
-  GRAVED
-    // String inside graves – any character is allowed inside graves except for the grave itself. It is handled by parser
-    : '`' ( INSIDE_GRAVES ) '`'
-    ;
-    fragment INSIDE_GRAVES
-      : ~[`]*
-      ;
   // This token changes the mode to 'conditional' mode, see below
   LCBRAC  : '{' -> pushMode(CONDITIONAL);
 mode CONDITIONAL;

--- a/antlr4/MODLLexer.g4
+++ b/antlr4/MODLLexer.g4
@@ -40,13 +40,13 @@ lexer grammar MODLLexer;
       : ~[\n\r] *
     ;
 
-  STRING : '# '? ( ESCAPED | UNRESERVED | GRAVED | HASH_PREFIX )+ ( ('#'? ' '+ '#'?) ( ESCAPED | UNRESERVED | GRAVED )+ )* ;
+  STRING : '# '? ( ESCAPED | UNRESERVED | HASH_PREFIX | QUOTED | GRAVED )+ ( ('#'? ' '+ '#'?) ( ESCAPED | UNRESERVED | QUOTED | GRAVED )+ )* ;
     // These two should be identical except for regex inversion on first
     fragment UNRESERVED
-      : ~ ( '#' | '`' | '{' | '}' | '(' | ')' | '[' | ']' | ';' | ' ' | '=' | ':' | '"' | '\b' | '\f' | '\n' | '\r' | '\t' )
+      : ~ ( '\\' | '~' | '#' | '`' | '{' | '}' | '(' | ')' | '[' | ']' | ';' | ' ' | '=' | ':' | '"' | '\b' | '\f' | '\n' | '\r' | '\t' )
     ;
     fragment RESERVED_CHARS
-      :   ( '#' | '`' | '{' | '}' | '(' | ')' | '[' | ']' | ';' | ' ' | '=' | ':' | '"' | '\b' | '\f' | '\n' | '\r' | '\t' )
+      :   ( '\\' | '~' | '#' | '`' | '{' | '}' | '(' | ')' | '[' | ']' | ';' | ' ' | '=' | ':' | '"' | '\b' | '\f' | '\n' | '\r' | '\t' )
     ;
     fragment ESCAPED
       // Standard JSON escaping, e.g. \t for tab
@@ -110,7 +110,7 @@ mode CONDITIONAL;
   CLCBRAC  : '{' -> pushMode(CONDITIONAL), type(LCBRAC);
   // A different version of string is defined to protect the reserved characters
   CSTRING
-    : (CESCAPED | CUNRESERVED | CGRAVED)+ (' '+ (CESCAPED | CUNRESERVED | CGRAVED)+)* -> type(STRING)
+    : (CESCAPED | CUNRESERVED | CGRAVED | CQUOTED )+ (' '+ (CESCAPED | CUNRESERVED | CGRAVED | CQUOTED)+)* -> type(STRING)
     ;
     fragment CUNRESERVED
     : ~ ('#' | '{' | '`' | '}' | '(' | ')' | ';' | ' ' | '=' | ':' | '"' | '?' | '/' | '>' | '<' | '!' | '|' | '&' | '\b' | '\f' | '\n' | '\r' | '\t' | '[' | ']' )

--- a/antlr4/MODLParser.g4
+++ b/antlr4/MODLParser.g4
@@ -61,7 +61,7 @@ modl_pair
   // It's also possible to do the same with an array pair
   // e.g. numbers[1;2;3] – equivalent to numbers=[1;2;3]
 
-  : ( STRING | QUOTED | NUMBER | NULL | TRUE | FALSE) EQUALS  modl_value_item                // key = value        (standard pair)
+  : ( GRAVED | QUOTED | STRING | NUMBER | NULL | TRUE | FALSE) EQUALS  modl_value_item                // key = value        (standard pair)
   | STRING modl_map                                                            // key( key = value ) (map pair)
   | STRING modl_array                                                          // key[ item; item ]  (array pair)
   ;

--- a/antlr4/MODLParser.g4
+++ b/antlr4/MODLParser.g4
@@ -170,8 +170,9 @@ modl_array_value_item
 
 modl_primitive
   : QUOTED
-  | NUMBER
+  | GRAVED
   | STRING
+  | NUMBER
   | TRUE
   | FALSE
   | NULL


### PR DESCRIPTION
Not sure what changes this will require in interpreters but seems to overcome most of the issues highlighted recently. It's been a while since I've worked with the grammar so this change may create more problems than it solves but worth a try.